### PR TITLE
Prevent input image from being dragged or selected accidentally

### DIFF
--- a/src/InputImage.tsx
+++ b/src/InputImage.tsx
@@ -79,13 +79,14 @@ function InputImage({ onInputImageLoad, inputImageRef }: InputImageProps) {
       modifiers={[restrictToParentWithOffset]}
     >
       <div className="flex flex-col gap-2 items-center">
-        <div className="relative">
+        <div className="relative select-none">
           <img
             style={imageStyle}
             ref={inputImageRef}
             src={inputImageDataUrl}
             onError={handleInputImageError}
             onLoad={onInputImageLoad}
+            draggable={false}
           />
           {glassesList.map(renderGlasses)}
         </div>


### PR DESCRIPTION
Adds `draggable={false}` and `select-none` properties to ImageInput component to prevent it from being dragged or selected accidentally when selecting the Glasses component. 

Before | After
-|-
<video src="https://github.com/user-attachments/assets/0f6facd8-6c08-4978-9408-830693f4be9c" /> | <video src="https://github.com/user-attachments/assets/1df6c79d-a767-4b78-8595-ff792ba17e50" />

